### PR TITLE
fix: require absolute paths and enforce voice sample containment

### DIFF
--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -1,4 +1,5 @@
 import { readFileSync, existsSync, statSync } from 'fs';
+import { isAbsolute, resolve, normalize } from 'path';
 import { Config } from '../types.js';
 
 export function loadConfig(path: string): Config {
@@ -16,5 +17,18 @@ export function loadConfig(path: string): Config {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(`Config is not valid JSON (${path}): ${msg}`);
   }
-  return Config.parse(parsed);
+  const cfg = Config.parse(parsed);
+
+  if (!isAbsolute(cfg.vault_path)) {
+    throw new Error(`Config vault_path must be an absolute path: ${cfg.vault_path}`);
+  }
+  if (!isAbsolute(cfg.voice_samples_path)) {
+    throw new Error(`Config voice_samples_path must be an absolute path: ${cfg.voice_samples_path}`);
+  }
+
+  return {
+    ...cfg,
+    vault_path: normalize(resolve(cfg.vault_path)),
+    voice_samples_path: normalize(resolve(cfg.voice_samples_path)),
+  };
 }

--- a/packages/core/src/lib/voice.ts
+++ b/packages/core/src/lib/voice.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 
 export interface VoiceSample {
   filename: string;
@@ -15,15 +15,27 @@ export function loadVoiceSamples(
   basePath: string,
   filenames: string[],
 ): VoiceLoadResult {
+  const resolvedBase = resolve(basePath);
   const samples: VoiceSample[] = [];
   const missing: string[] = [];
+
   for (const filename of filenames) {
-    const path = join(basePath, filename);
-    if (!existsSync(path)) {
+    const resolvedPath = resolve(resolvedBase, filename);
+    // Containment check: resolved path must be inside the base directory
+    if (
+      resolvedPath !== resolvedBase &&
+      !resolvedPath.startsWith(resolvedBase + '/') &&
+      !resolvedPath.startsWith(resolvedBase + '\\') // Windows
+    ) {
+      throw new Error(
+        `Voice sample filename escapes voice_samples_path: ${filename} (resolved to ${resolvedPath}, must be inside ${resolvedBase})`,
+      );
+    }
+    if (!existsSync(resolvedPath)) {
       missing.push(filename);
       continue;
     }
-    samples.push({ filename, content: readFileSync(path, 'utf-8') });
+    samples.push({ filename, content: readFileSync(resolvedPath, 'utf-8') });
   }
   return { samples, missing };
 }

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -58,4 +58,33 @@ describe('loadConfig', () => {
     mkdirSync(dirPath);
     expect(() => loadConfig(dirPath)).toThrow(/not a file/);
   });
+
+  it('throws when vault_path is relative', () => {
+    const configPath = join(tmp, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      vault_path: 'relative/path',
+      voice_samples_path: '/abs/path',
+    }));
+    expect(() => loadConfig(configPath)).toThrow(/vault_path must be an absolute path/);
+  });
+
+  it('throws when voice_samples_path is relative', () => {
+    const configPath = join(tmp, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      vault_path: '/abs/path',
+      voice_samples_path: 'relative/path',
+    }));
+    expect(() => loadConfig(configPath)).toThrow(/voice_samples_path must be an absolute path/);
+  });
+
+  it('normalizes path with traversal segments', () => {
+    const configPath = join(tmp, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      vault_path: '/tmp/a/b/../c',
+      voice_samples_path: '/tmp/x/y/../z',
+    }));
+    const cfg = loadConfig(configPath);
+    expect(cfg.vault_path).toBe('/tmp/a/c');
+    expect(cfg.voice_samples_path).toBe('/tmp/x/z');
+  });
 });

--- a/packages/core/tests/voice.test.ts
+++ b/packages/core/tests/voice.test.ts
@@ -38,4 +38,13 @@ describe('loadVoiceSamples', () => {
     expect(result.samples).toEqual([]);
     expect(result.missing).toEqual([]);
   });
+
+  it('throws when filename escapes basePath via traversal', () => {
+    writeFileSync(join(tmp, 'a.md'), '# Post A');
+    expect(() => loadVoiceSamples(tmp, ['../outside.md'])).toThrow(/escapes voice_samples_path/);
+  });
+
+  it('throws when filename is an absolute path outside basePath', () => {
+    expect(() => loadVoiceSamples(tmp, ['/etc/passwd'])).toThrow(/escapes voice_samples_path/);
+  });
 });


### PR DESCRIPTION
Closes #1.

## Summary

Two changes closing the path traversal holes surfaced in the v0.1.0 audit:

**1. `loadConfig` requires absolute paths + normalizes.**
`vault_path` and `voice_samples_path` must satisfy `path.isAbsolute()` — relative values throw with a clear error. Both paths are passed through `resolve() + normalize()` so segments like `a/b/../c` collapse to `a/c`.

**2. `loadVoiceSamples` rejects filenames that escape `basePath`.**
Uses `path.resolve(basePath, filename)` then requires the result to equal `basePath` or start with `basePath + '/'` (or `\\` on Windows). Blocks:
- `../secret.txt` traversal outside the voice dir
- Absolute paths pointing outside (e.g. `/etc/passwd`)

## Test plan

- [x] 61/61 tests pass (56 prior + 5 new across `config.test.ts` and `voice.test.ts`)
- [x] Smoke: absolute path with traversal `/tmp/a/b/../c` normalizes and works; relative `relative/path` rejects with `Error: Config vault_path must be an absolute path: relative/path`
- [x] Reviewer smoke independently verified prefix-sibling attack (`/tmp/voice2/...` against base `/tmp/voice`) correctly rejected

## Minor follow-up flagged by reviewer (non-blocking)

- Add a test for the prefix-sibling attack to pin down the trailing-separator requirement (prevents a future refactor from regressing to bare `startsWith(base)`).

## Breaking change risk

None for users following `docs/setup.md` (all examples already use absolute paths). A user who typed `~/vault` would hit `isAbsolute` rejection — Node doesn't expand `~`. Error message is clear and actionable.
