### PR TITLE
chore: minor polish from PR review

### DIFF
--- a/commands/outreach-log.md
+++ b/commands/outreach-log.md
@@ -42,6 +42,8 @@ else
 fi
 ```
 
+Each value must fit on one line (read -r reads one line).
+
 Substitute `<SLUG>`, `<ACTION>`, and `<DATE_OR_EMPTY>` (leave blank for today). Values are read verbatim inside single-quoted heredocs, so no escaping is needed.
 
 ## After logging

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "test": "tsc && vitest run",
-    "test:watch": "vitest",
+    "test:watch": "tsc && vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/core/tests/cli.smoke.test.ts
+++ b/packages/core/tests/cli.smoke.test.ts
@@ -4,12 +4,19 @@ import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
+// Note: these tests spawn the compiled CLI at dist/cli.js. `pnpm test` runs tsc first.
+// In `pnpm test:watch`, tsc runs once on startup but is NOT re-run on source changes —
+// if you edit src/ while in watch mode, re-run `pnpm build` manually or use a separate
+// `tsc --watch` shell to keep dist/cli.js fresh.
+
 const CLI_PATH = resolve(__dirname, '..', 'dist', 'cli.js');
 
 function run(args: string[]): { status: number; stdout: string; stderr: string } {
+  const env = { ...process.env };
+  delete env.OUTREACH_AUTOPILOT_CONFIG;
   const res = spawnSync(process.execPath, [CLI_PATH, ...args], {
     encoding: 'utf-8',
-    env: { ...process.env, OUTREACH_AUTOPILOT_CONFIG: undefined },
+    env,
   });
   return {
     status: res.status ?? -1,
@@ -197,5 +204,16 @@ describe('CLI smoke: missing config', () => {
     ]);
     expect(res.status).not.toBe(0);
     expect(res.stderr).toContain('Config not found');
+  });
+
+  it('returns non-zero with clear error when config JSON is invalid', () => {
+    const badConfig = join(tmp, 'bad.json');
+    writeFileSync(badConfig, '{ not valid json');
+    const res = run([
+      'target', 'list',
+      '--config', badConfig,
+    ]);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain('not valid JSON');
   });
 });

--- a/packages/core/tests/voice.test.ts
+++ b/packages/core/tests/voice.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { loadVoiceSamples } from '../src/lib/voice';
@@ -46,5 +46,14 @@ describe('loadVoiceSamples', () => {
 
   it('throws when filename is an absolute path outside basePath', () => {
     expect(() => loadVoiceSamples(tmp, ['/etc/passwd'])).toThrow(/escapes voice_samples_path/);
+  });
+
+  it('throws on prefix-sibling attack (adjacent directory with same prefix)', () => {
+    const voice = join(tmp, 'voice');
+    const voiceTwo = join(tmp, 'voice2');
+    mkdirSync(voice);
+    mkdirSync(voiceTwo);
+    writeFileSync(join(voiceTwo, 'evil.md'), '# Evil');
+    expect(() => loadVoiceSamples(voice, ['../voice2/evil.md'])).toThrow(/escapes voice_samples_path/);
   });
 });


### PR DESCRIPTION
Handles 5 non-blocking minor items surfaced during PR review of #4, #5, #6. Single commit since they're all small polish.

## Changes

1. **`commands/outreach-log.md`** — added "Each value must fit on one line" note matching the one in `outreach-target-add.md` (heredoc reads one line, so multi-line action text silently truncates)
2. **`packages/core/package.json`** — `test:watch` now does a one-time `tsc` before entering vitest watch mode (prevents spawning a stale `dist/cli.js`)
3. **`packages/core/tests/cli.smoke.test.ts`** — (a) added a caveat comment explaining the watch-mode tsc-staleness limitation, (b) replaced `OUTREACH_AUTOPILOT_CONFIG: undefined` in spawn env with explicit `delete` (spawnSync stringifies `undefined` to the literal "undefined"), (c) added invalid-JSON config smoke test
4. **`packages/core/tests/voice.test.ts`** — added prefix-sibling attack test (`../voice2/evil.md` against base `/tmp/voice`) to pin down the trailing-separator requirement in the containment check

## Test plan

- [x] 74/74 tests pass (72 prior + 2 new)
- [x] `tsc --noEmit` clean
- [x] `pnpm test:watch` does initial tsc then enters vitest watch
